### PR TITLE
Export attributes to support Hapi 6.x plugin convention

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,3 +121,7 @@ exports.register = function (plugin, options, next) {
         next();
     });
 };
+
+exports.register.attributes = {
+  pkg: require('./package.json')
+};


### PR DESCRIPTION
This makes the plugin Hapi 6.x friendly.
