### PR TITLE
Upgrade moonboots to a version which throws on build errors if not in dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "main": "index.js",
   "dependencies": {
     "async": "^0.7.0",
-    "moonboots": "^2.0.6"
+    "moonboots": "^3.0.0"
   },
   "devDependencies": {
     "complexity-report": "^1.0.0",


### PR DESCRIPTION
I made it a major version in moonboots, I'm guessing we probably wanna do the same here.
