### PR TITLE
Removed dependency on make for test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,0 @@
-test:
-		@node node_modules/lab/bin/lab -c
-test-no-cov:
-		@node node_modules/lab/bin/lab
-
-.PHONY: test test-no-cov

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "precommit-hook": "^1.0.7"
   },
   "scripts": {
-    "test": "make test"
+    "test": "node node_modules/lab/bin/lab -c",
+    "test-no-cov": "node node_modules/lab/bin/lab"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
To execute test use "npm test" as before.
To execute no coverage test use "npm run-script test-no-cov".