### PR TITLE
add last-modified header to .js and .css

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ function setDefaults(options, next) {
 
 exports.register = function (plugin, clientConfig, next) {
     var clientApp;
+    var lastModified = new Date();
     var appOptions = setDefaults(clientConfig);
     var servers = (appOptions.labels) ? plugin.select(appOptions.labels) : plugin;
     if (appOptions.logLevel !== 'none') {
@@ -80,7 +81,12 @@ exports.register = function (plugin, clientConfig, next) {
     appOptions.jsConfig.handler = appOptions.jsConfig.handler ||
         function jsRouteHandler(request, reply) {
             getJsSource(function _getJsSource(err, js) {
+              if (!appOptions.developmentMode) {
+                reply(js).header('content-type', 'text/javascript; charset=utf-8').header('last-modified', lastModified);
+              }
+              else {
                 reply(js).header('content-type', 'text/javascript; charset=utf-8');
+              }
             });
         };
 
@@ -94,7 +100,12 @@ exports.register = function (plugin, clientConfig, next) {
     appOptions.cssConfig.handler = appOptions.cssConfig.handler ||
         function cssRouteHandler(request, reply) {
             getCssSource(function _getCssSource(err, css) {
+              if (!appOptions.developmentMode){
+                reply(css).header('content-type', 'text/css; charset=utf-8').header('last-modified', lastModified);
+              }
+              else {
                 reply(css).header('content-type', 'text/css; charset=utf-8');
+              }
             });
         };
     if (!appOptions.developmentMode) {

--- a/test/defaults.js
+++ b/test/defaults.js
@@ -67,8 +67,8 @@ Lab.experiment('default happy path tests', function () {
             method: 'GET',
             url: '/app'
         }, function _getApp(res) {
-            Expect(res.statusCode, 'response code').to.equal(200);
-            Expect(res.payload, 'response body').to.equal(appSource, 'application source');
+            Expect(res.statusCode).to.equal(200);
+            Expect(res.payload).to.equal(appSource);
             done();
         });
     });
@@ -77,8 +77,8 @@ Lab.experiment('default happy path tests', function () {
             method: 'GET',
             url: '/app.nonCached.js'
         }, function _getJs(res) {
-            Expect(res.statusCode, 'response code').to.equal(200);
-            Expect(res.payload, 'response body').to.equal(jsSource, 'js source');
+            Expect(res.statusCode).to.equal(200);
+            Expect(res.payload).to.equal(jsSource);
             done();
         });
     });
@@ -87,20 +87,20 @@ Lab.experiment('default happy path tests', function () {
             method: 'GET',
             url: '/app.nonCached.css'
         }, function _getJs(res) {
-            Expect(res.statusCode, 'response code').to.equal(200);
-            Expect(res.payload, 'response body').to.equal(cssSource, 'css source');
+            Expect(res.statusCode).to.equal(200);
+            Expect(res.payload).to.equal(cssSource);
             done();
         });
     });
     Lab.test('clientConfig is exposed', function (done) {
         server.plugins.moonboots_hapi.clientConfig(function (config) {
-            Expect(config, 'client config').to.equal(moonboots_hapi_options, 'moonboots-hapi config');
+            Expect(config).to.equal(moonboots_hapi_options);
             done();
         });
     });
     Lab.test('clientApp is exposed', function (done) {
         server.plugins.moonboots_hapi.clientApp(function (clientApp) {
-            Expect(clientApp, 'client app').to.be.instanceOf(Moonboots);
+            Expect(clientApp).to.be.instanceOf(Moonboots);
             done();
         });
     });

--- a/test/devMode.js
+++ b/test/devMode.js
@@ -83,6 +83,7 @@ Lab.experiment('developmentMode flag properly affects caching', function () {
             url: '/app',
         }, function _devApp(res) {
             Expect(res.headers['cache-control'], 'cache-control header').to.equal('no-store');
+            Expect(res.headers['last-modified'], 'last-modified header').to.be.undefined();
             done();
         });
     });
@@ -92,6 +93,7 @@ Lab.experiment('developmentMode flag properly affects caching', function () {
             url: '/' + devMoonboots.jsFileName()
         }, function _devJs(res) {
             Expect(res.headers['cache-control'], 'cache-control header').to.equal('no-cache');
+            Expect(res.headers['last-modified'], 'last-modified header').to.be.undefined();
             done();
         });
     });
@@ -101,6 +103,7 @@ Lab.experiment('developmentMode flag properly affects caching', function () {
             url: '/' + devMoonboots.cssFileName()
         }, function _devCss(res) {
             Expect(res.headers['cache-control'], 'cache-control header').to.equal('no-cache');
+            Expect(res.headers['last-modified'], 'last-modified header').to.be.undefined();
             done();
         });
     });
@@ -110,6 +113,7 @@ Lab.experiment('developmentMode flag properly affects caching', function () {
             url: '/app'
         }, function _prodApp(res) {
             Expect(res.headers['cache-control'], 'cache-control header').to.equal('no-store');
+            Expect(res.headers['last-modified'], 'last-modified header').to.be.undefined();
             done();
         });
     });
@@ -131,6 +135,33 @@ Lab.experiment('developmentMode flag properly affects caching', function () {
             done();
         });
     });
+    
+    Lab.test('prodJs last-modified', function (done) {
+        prodServer.inject({
+            method: 'GET',
+            url: '/' + prodMoonboots.jsFileName()
+        }, function _prodJs(res) {
+          setTimeout(function(){ 
+              prodServer.inject({
+                method: 'GET',
+                url: '/' + prodMoonboots.jsFileName()
+            }, function _prodJs2(res2) {              
+              Expect(res.headers['last-modified']).to.equal(res2.headers['last-modified']);
+              done();
+          });
+        },1500);
+      });
+    });
+    
+    Lab.test('prodJs', function (done) {
+        prodServer.inject({
+            method: 'GET',
+            url: '/' + prodMoonboots.jsFileName()
+        }, function _prodJs(res) {
+            Expect(res.headers['cache-control'], 'cache-control header').to.equal('max-age=31104000, must-revalidate');
+            done();
+        });
+    });
 
     Lab.test('in development mode, simultaneous requests should all get same code', function (done) {
         var result1, result2;
@@ -148,8 +179,8 @@ Lab.experiment('developmentMode flag properly affects caching', function () {
             getJS,
             getJS
         ], function (err, results) {
-            Expect(results[0].length).to.equal(results[1].length, 'Should be same code');
-            Expect(results[0].length).to.equal(results[2].length, 'Should be same code');
+            Expect(results[0].length).to.equal(results[1].length);
+            Expect(results[0].length).to.equal(results[2].length);
             done();
         });
     });

--- a/test/labels.js
+++ b/test/labels.js
@@ -54,7 +54,7 @@ Lab.experiment('labels parameter', function () {
             url: '/app'
         }, function _getApp(res) {
             Expect(res.statusCode, 'response code').to.equal(200);
-            Expect(res.payload, 'response body').to.equal(appSource, 'application source');
+            Expect(res.payload, 'response body').to.equal(appSource);
             done();
         });
     });

--- a/test/routes.js
+++ b/test/routes.js
@@ -76,7 +76,7 @@ Lab.experiment('routes', function () {
             url: '/app'
         }, function _getApp(res) {
             Expect(res.statusCode, 'response code').to.equal(200);
-            Expect(res.payload, 'response body').to.equal(appSource, 'application source');
+            Expect(res.payload, 'response body').to.equal(appSource);
             done();
         });
     });
@@ -86,7 +86,7 @@ Lab.experiment('routes', function () {
             url: '/moonboots-hapi-js.nonCached.js'
         }, function _getJs(res) {
             Expect(res.statusCode, 'response code').to.equal(200);
-            Expect(res.payload, 'response body').to.equal(jsSource, 'js source');
+            Expect(res.payload, 'response body').to.equal(jsSource);
             done();
         });
     });
@@ -96,7 +96,7 @@ Lab.experiment('routes', function () {
             url: '/moonboots-hapi-css.nonCached.css'
         }, function _getJs(res) {
             Expect(res.statusCode, 'response code').to.equal(200);
-            Expect(res.payload, 'response body').to.equal(cssSource, 'css source');
+            Expect(res.payload, 'response body').to.equal(cssSource);
             done();
         });
     });
@@ -148,7 +148,7 @@ Lab.experiment('disabling routes', function () {
             url: '/moonboots-hapi-js.nonCached.js'
         }, function _getJs(res) {
             Expect(res.statusCode, 'response code').to.equal(200);
-            Expect(res.payload, 'response body').to.equal(jsSource, 'js source');
+            Expect(res.payload, 'response body').to.equal(jsSource);
             done();
         });
     });
@@ -158,7 +158,7 @@ Lab.experiment('disabling routes', function () {
             url: '/moonboots-hapi-css.nonCached.css'
         }, function _getJs(res) {
             Expect(res.statusCode, 'response code').to.equal(200);
-            Expect(res.payload, 'response body').to.equal(cssSource, 'css source');
+            Expect(res.payload, 'response body').to.equal(cssSource);
             done();
         });
     });


### PR DESCRIPTION
@wraithgar this PR sets a last-modified header on the .js and .css bundles (when not in development mode).  This lets us take advantage of browser caching and speeds up page loads, especially on mobile.